### PR TITLE
Add episode 1 redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
 [build]
 publish = "public"
 command = "gatsby build"
+
+[[redirects]]
+from = "/1"
+to = "/posts/Episode-1/"
+status = 301
+force = true


### PR DESCRIPTION
In theory, this lets us just say `devopspartygames.com/1` to make it easier to remember an episode number.